### PR TITLE
Update dependency version of File::Temp to one that has the PERMS flag

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,7 +12,8 @@ Carp=1.12
 Exporter=5.57
 File::Basename=0
 File::Slurper=0
-File::Temp=0.2307
+# We rely implicitly on PERMS flag being obeyed, which was not present prior to this version
+File::Temp=0.2310
 
 [Prereqs / TestRequires]
 Test::Exception=0


### PR DESCRIPTION
This will instruct clients to update their copy of File::Temp when installing this module from CPAN.

Per File::Temp's POD:
```
PERMS flag available since 0.2310.
```

dist.ini had a version 3 releases behind this.